### PR TITLE
Add license info to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
     author="Romain Jolivet, Angelique Benoit",
     author_email="insar@geologie.ens.fr",
 
+    license='GPL-3.0-or-later',
+    llicense_files=('LICENSE',),
+
     url="https://github.com/insarlab/PyAPS",
     project_urls={
         "Bug Reports": "https://github.com/insarlab/PyAPS/issues",
@@ -44,4 +47,4 @@ setup(
     # data files
     include_package_data=True,
     package_data={"pyaps3": ["*.cfg"]},
-) 
+)


### PR DESCRIPTION
These changes will cause the license to be reported on PyPI and include the license file in the source dist. 

This would allow me to base the conda-forge recipe on the PyPI distribution making the feedstock *slightly* easier to maintain and ensure the PyPI and conda-forge package are coherent. 

--- 

Note: There's no need to release this anytime soon, but would be nice for the next release. 