### PR TITLE
PyAPS.getdelay(): support return matrix w/o input obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,26 @@ or via `pip` as:
 pip install pyaps3
 ```
 
-One could also install the development version via `pip` as:
+#### Build from source
+
+The development version can be installed via `pip` as:
 
 ```bash
 pip install git+https://github.com/insarlab/PyAPS.git
+```
+
+Or build from source manually as:
+
+```bash
+git clone https://github.com/insarlab/PyAPS.git
+conda install -c conda-forge --file PyAPS/requirements.txt
+python -m pip install -e PyAPS
+```
+
+Test the installation by running:
+
+```bash
+python PyAPS/tests/test_calc.py
 ```
 
 ### 2. Account setup for [ERA5](https://retostauffer.org/code/Download-ERA5/)
@@ -42,17 +58,14 @@ where 12345 is your personal user ID (UID), the part behind the colon is your pe
 
 + **Make sure** that you accept the data license in the Terms of use on ECMWF website.
 
-### 3. Testing
-
-Run the following to test the installation and account setup:
++ Test the account setup by running:
 
 ```bash
 git clone https://github.com/insarlab/PyAPS.git --depth 1
 python PyAPS/tests/test_dload.py
-python PyAPS/tests/test_calc.py
 ```
 
-### 4. Citing this work
+### 3. Citing this work
 
 The methodology and validation can be found in:
 

--- a/src/pyaps3/__init__.py
+++ b/src/pyaps3/__init__.py
@@ -4,13 +4,11 @@ PyAPS module to compute InSAR phase delay maps from weather models.
 Written by Romain Jolivet <rjolivet@gps.caltech.edu> and Piyush Agram <piyush@gps.caltech.edu>. The original Fortran package was written by Romain Jolivet and the Python version including support for different models was written by Piyush Agram.
 
 .. note::
-	Details of the python module can be obtained `here. <http://code.google.com/p/pyaps>`_
+    Details of the python module can be obtained `here. <http://code.google.com/p/pyaps>`_
 '''
 
-__all__ = ['geocoord','rdrcoord','autoget','objects']
+__all__ = ['autoget','objects']
 
-#from .geocoord import PyAPS_geo
-#from .rdrcoord import PyAPS_rdr
 from .objects import PyAPS
 from .autoget import *
 

--- a/src/pyaps3/ecmwf.py
+++ b/src/pyaps3/ecmwf.py
@@ -31,8 +31,6 @@ class ECMWFDataServer:
         response = urllib.request.urlopen(req)
 
         json = response.read();
-
-        undef = None;
         json = eval(json)
 
         if json != None:
@@ -97,7 +95,7 @@ class ECMWFDataServer:
     def _transfer(self,url,path):
         result =  urllib.request.urlretrieve(url,path)
         return long(result[1]['content-length'])
-        
+
     def _bytename(self,size):   
         next = {'':'K','K':'M','M':'G','G':'T','T':'P'}
         l    = ''

--- a/src/pyaps3/geocoord.py
+++ b/src/pyaps3/geocoord.py
@@ -9,6 +9,7 @@
 
 
 import os.path
+import sys
 import numpy as np
 import scipy.integrate as intg
 import scipy.interpolate as si

--- a/src/pyaps3/getecmwf.py
+++ b/src/pyaps3/getecmwf.py
@@ -9,7 +9,7 @@
 #!/usr/bin/python
 from ecmwf import ECMWFDataServer
 
-def getfiles(bdate,hr,filedir,model,humidity='Q')
+def getfiles(bdate,hr,filedir,model,humidity='Q'):
 
         server = ECMWFDataServer('https://api.ecmwf.int/v1',
                 'yourkey',

--- a/src/pyaps3/getoper.py
+++ b/src/pyaps3/getoper.py
@@ -17,7 +17,7 @@ from ecmwf import ECMWFDataServer
 ####    )
 
 
-def getfiles(bdate,hr,filedir,humidity='Q')
+def getfiles(bdate,hr,filedir,humidity='Q'):
 
         server = ECMWFDataServer('https://api.ecmwf.int/v1',
         'yourkey',

--- a/src/pyaps3/processor.py
+++ b/src/pyaps3/processor.py
@@ -6,10 +6,12 @@
 # Ecole Normale Superieure, Paris                          #
 # Contact: insar@geologie.ens.fr                           #
 ############################################################
+
+
 import numpy as np
 import scipy.interpolate as intp
 import scipy.integrate as intg
-import scipy.spatial as ss
+
 
 def initconst():
     '''Initialization of various constants needed for computing delay.

--- a/src/pyaps3/utils.py
+++ b/src/pyaps3/utils.py
@@ -129,13 +129,13 @@ def read_metadata(fname, latfile=None, lonfile=None, full=False, verbose=False):
 
         # default latfile
         if not latfile:
-            latfile = os.path.join(os.path.dirname(xmlfile),'lat.rdr')
+            latfile = os.path.join(os.path.dirname(fname),'lat.rdr')
             if not os.path.isfile(latfile):
                 raise FileNotFoundError("No latitude file found in ISCE style!")
 
         # default lonfile
         if not lonfile:
-            lonfile = os.path.join(os.path.dirname(xmlfile),'lon.rdr')
+            lonfile = os.path.join(os.path.dirname(fname),'lon.rdr')
             if not os.path.isfile(lonfile):
                 raise FileNotFoundError("No longitude file found in ISCE style!")
 
@@ -154,8 +154,8 @@ def read_metadata(fname, latfile=None, lonfile=None, full=False, verbose=False):
     lon[2] = float(meta['LON_REF3'])
     lat[3] = float(meta['LAT_REF4'])
     lon[3] = float(meta['LON_REF4'])
-    rgpix = 90.0  #following rd_rsc()
-    azpix = 90.0  #following rd_rsc()
+    rgpix = 90.0
+    azpix = 90.0
     dpix = np.sqrt(6.25*rgpix*rgpix + azpix*azpix)
     if full:
         return lon,lat,nx,ny,dpix,meta
@@ -184,8 +184,8 @@ def read_isce_xml(xmlfile):
                 v_step  = float(child.find("./property[@name='delta']").find('value').text)
                 v_first = float(child.find("./property[@name='startingvalue']").find('value').text)
                 if abs(v_step) < 1. and abs(v_step) > 1e-7:
-                    xmlDict['{}_STEP'.format(prefix)] = v_step
-                    xmlDict['{}_FIRST'.format(prefix)] = v_first - v_step / 2.
+                    meta['{}_STEP'.format(prefix)] = v_step
+                    meta['{}_FIRST'.format(prefix)] = v_first - v_step / 2.
 
     # convert key name from isce to roipac
     isce2roipacKeyDict = {

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -29,12 +29,7 @@ grb_file1 = os.path.join(data_dir, 'ERA5/ERA5_N30_N40_E120_E140_20101017_14.grb'
 grb_file2 = os.path.join(data_dir, 'ERA5/ERA5_N30_N40_E120_E140_20110117_14.grb')
 obj1 = pa.PyAPS(grb_file1, dem=dem, inc=inc, lat=lat, lon=lon, grib='ERA5', verb=True)
 obj2 = pa.PyAPS(grb_file2, dem=dem, inc=inc, lat=lat, lon=lon, grib='ERA5', verb=True)
-
-phs1 = np.zeros((obj1.ny, obj1.nx), dtype=np.float32)
-phs2 = np.zeros((obj2.ny, obj2.nx), dtype=np.float32)
-obj1.getdelay(phs1)
-obj2.getdelay(phs2)
-phs = phs2 - phs1
+phs = obj2.getdelay() - obj1.getdelay()
 
 # plot
 date12 = '{}_{}'.format(grb_file1.split('_')[-2], grb_file2.split('_')[-2])

--- a/tests/test_dload.py
+++ b/tests/test_dload.py
@@ -2,7 +2,6 @@
 # Author: Zhang Yunjun, Nov 15, 2021
 
 
-import os
 import pyaps3 as pa
 
 print('------------------------------------------------')


### PR DESCRIPTION
+ objects.PyAPS.getdelay(): separate dataobj to dout and outFile for simplicity
   - remove dataobj as it's over complicated
   - use dout in matrix as output for simplicity on the user side
   - set dout=None as default for backward compatiability
   - set outFile to write output in file for backward compatiability

+ tests/test_calc.py: use the new recommended simple getdelay()

+ bugs fix in the following scripts:
   - utils.read_metadata()
   - getecmwf.py
   - getoper.py

+ README.installation: add more install note on development

+ codacy suggestions for code cleanup