### PR TITLE
license: switch from GPLv3 to GPLv3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Language](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/)
 [![CircleCI](https://img.shields.io/circleci/build/github/insarlab/PyAPS.svg?logo=circleci&label=test)](https://circleci.com/gh/insarlab/PyAPS)
 [![Version](https://img.shields.io/github/v/release/insarlab/PyAPS?color=green)](https://github.com/insarlab/PyAPS/releases)
-[![License](https://img.shields.io/badge/license-GPLv3-yellow.svg)](https://github.com/insarlab/PyAPS/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-GPLv3+-yellow.svg)](https://github.com/insarlab/PyAPS/blob/main/LICENSE)
 [![Citation](https://img.shields.io/badge/doi-10.1029%2F2011GL048757-blue)](https://doi.org/10.1029/2011GL048757)
 
 ## PyAPS - Python based Atmospheric Phase Screen estimation

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,25 @@ setup(
     name='pyaps3',
     version=version,
     description="Python based Atmospheric Phase Screen Estimation",
+    url="https://github.com/insarlab/PyAPS",
+    download_url=("https://github.com/insarlab/PyAPS/archive/v{}.tar.gz".format(version)),
     long_description=long_description,
     long_description_content_type="text/markdown",
-
     author="Romain Jolivet, Angelique Benoit",
     author_email="insar@geologie.ens.fr",
+    license="GPL-3.0-or-later",
+    license_files=("LICENSE",),
 
-    license='GPL-3.0-or-later',
-    license_files=('LICENSE',),
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords="InSAR, troposphere, geodesy, geophysics, ERA5",
 
-    url="https://github.com/insarlab/PyAPS",
     project_urls={
         "Bug Reports": "https://github.com/insarlab/PyAPS/issues",
         "Documentation": "https://github.com/insarlab/PyAPS/tree/main/docs",
@@ -41,6 +50,7 @@ setup(
     package_dir={"": "src"},        # tell distutils packages are under src
 
     # dependencies
+    python_requires=">=3.6",
     install_requires=[
         'cdsapi',
         'matplotlib',
@@ -54,5 +64,7 @@ setup(
 
     # data files
     include_package_data=True,
-    package_data={"pyaps3": ["*.cfg"]},
+    package_data={
+        "pyaps3": ["*.cfg"],
+    },
 )

--- a/src/pyaps3/__init__.py
+++ b/src/pyaps3/__init__.py
@@ -9,12 +9,11 @@ Written by Romain Jolivet <rjolivet@gps.caltech.edu> and Piyush Agram <piyush@gp
 
 __all__ = ['autoget','objects']
 
-from .objects import PyAPS
-from .autoget import ECMWFdload, MERRAdload, NARRdload
+from pyaps3.objects import PyAPS
+from pyaps3.autoget import ECMWFdload, MERRAdload, NARRdload
 
 # get version info
-from .version import release_version, release_date
-__version__ = release_version
+from pyaps3.version import release_version as __version__
 
 ############################################################
 # Program is part of PyAPS                                 #


### PR DESCRIPTION
This PR includes the following changes:

+ `README.md/setup.py`: switch from `GPLv3` to `GPLv3+`. The LICENSE file is still the same. Related to https://github.com/insarlab/PySolid/issues/35. 

+ `__init__.py`: use absolute module imports for top-level functions/variables

+ `setup.py`: add download_url, classifiers, keywords, python_requires

@jolivetr Could you please take a look at this PR when you got a chance?