### PR TITLE
revert "tolerate duplicates for TestPyPI"

### DIFF
--- a/.github/workflows/build-n-publish-to-pypi.yml
+++ b/.github/workflows/build-n-publish-to-pypi.yml
@@ -61,19 +61,19 @@ jobs:
           name: artifact
           path: dist
 
-      - name: Publish developed version 📦 to Test PyPI
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          # tolerate release package file duplicates for TestPyPI
-          skip_existing: true
-          verbose: true
-
       - name: Publish released version 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
+
+      - name: Publish developed version 📦 to Test PyPI
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: false
+          verbose: true
+

--- a/.github/workflows/build-n-publish-to-pypi.yml
+++ b/.github/workflows/build-n-publish-to-pypi.yml
@@ -61,13 +61,6 @@ jobs:
           name: artifact
           path: dist
 
-      - name: Publish released version 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
-
       - name: Publish developed version 📦 to Test PyPI
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -75,5 +68,12 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           skip_existing: false
+          verbose: true
+
+      - name: Publish released version 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
 


### PR DESCRIPTION
This attempts to upload version 0.3.2 to PyPI, in spite of the uploading error in TestPyPI due to the existing version 0.3.2 there.

Update: it is a bad idea to change the `TestPyPI --> PyPI` order. Modify the PR to just revert the "tolerate duplicates" change, which could not solve the upload error to testpypi. Will manually upload it to PyPI for this release.