### PR TITLE
pyproject.toml: fix typo on package-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ python PyAPS/tests/test_calc.py
 ERA5 data set is redistributed over the Copernicus Climate Data Store (CDS). Registration is required for the data access and downloading.
 
 + [Create a new account](https://cds.climate.copernicus.eu/user/register) on the CDS website if you don't own a user account yet. 
-+ Create local key file. Create a file named `.cdsapirc` in your home directory and add the following two lines:
++ Create the local file `$HOME/.cdsapirc` and add the following two lines:
 
 ```shell
 url: https://cds.climate.copernicus.eu/api/v2
 key: 12345:abcdefghij-134-abcdefgadf-82391b9d3f
 ```
 
-where 12345 is your personal user ID (UID), the part behind the colon is your personal API key. More details can be found [here](https://cds.climate.copernicus.eu/api-how-to).
+where 12345 is your personal user ID (UID), the part behind the colon is your personal API key. More details can be found [here](https://cds.climate.copernicus.eu/api-how-to). Alternatively, you could also edit the `model.cfg` file in the package directory, `site-packages/pyaps3` if installed via conda, and fill in the `[CDS]` section.
 
 + **Make sure** that you accept the data license in the Terms of use on ECMWF website.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ zip-safe = false
 where = ["src"]
 
 [tool.setuptools.package-data]
-pysolid = ["*.cfg"]
+pyaps3 = ["*.cfg"]
 
 [tool.setuptools_scm]
 version_scheme = "post-release"


### PR DESCRIPTION
+ `pyproject.toml`: fix typo on `package-data` section to add `model.cfg` file to the package directory while installing via conda/pip, as found out in https://github.com/insarlab/MintPy/issues/1008.

+ README.md: add a description to fill the account info in the `model.cfg` file, as an alternative to the `~/.cdsapirc` file.