### PR TITLE
`processor.PTV2del()`: rename integrate func call to scipy-1.14

### DIFF
--- a/src/pyaps3/processor.py
+++ b/src/pyaps3/processor.py
@@ -216,13 +216,13 @@ def PTV2del(Presi,Tempi,Vpri,hgt,cdict,verbose=False):
     DDry2[:,:,:] = k1*Rd*(Presi[:,:,:] - Presi[:,:,-1][:,:,np.newaxis])*1.0e-6/g
 
     #Wet delay
-    S1 = intg.cumtrapz(WonT,x=hgt,axis=-1)
+    S1 = intg.cumulative_trapezoid(WonT,x=hgt,axis=-1)
     val = 2*S1[:,:,-1]-S1[:,:,-2]
     val = val[:,:,None]
     S1 = np.concatenate((S1,val),axis=-1)
     del WonT
 
-    S2 = intg.cumtrapz(WonT2,x=hgt,axis=-1)
+    S2 = intg.cumulative_trapezoid(WonT2,x=hgt,axis=-1)
     val = 2*S2[:,:,-1]-S2[:,:,-2]
     val = val[:,:,None]
     S2 = np.concatenate((S2,val),axis=-1)


### PR DESCRIPTION
+ `processor.PTV2del()`: rename the integration function call from `scipy.integrate.cumtrapz()` to `scipy.integrate.cumulative_trapezoid()`, as the former has been removed from [scipy since version 1.14](https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations).