### PR TITLE
`pyproject.toml`: use dynamic dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             export PYTHONUNBUFFERED=1
             # install dependencies and source code
             source activate root
-            mamba install --verbose --yes --file ${PYAPS_HOME}/requirements.txt
+            mamba install --verbose --yes --file ${PYAPS_HOME}/requirements.txt --file ${PYAPS_HOME}/tests/requirements.txt
             python -m pip install ${PYAPS_HOME}
 
       - run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]", "wheel"]
+requires = ["setuptools>=64.0", "setuptools_scm[toml]>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,8 +9,8 @@ authors = [
     {name="Romain Jolivet", email="insar@geologie.ens.fr"},
     {name="Angelique Benoit"},
 ]
-readme = "README.md"
 requires-python = ">=3.8"
+
 keywords = ["InSAR", "troposphere", "geodesy", "geophysics", "ERA5"]
 license = {text = "GPL-3.0-or-later"}
 classifiers=[
@@ -21,25 +21,27 @@ classifiers=[
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]
-dependencies = [
-    "cdsapi>=0.7.0",
-    "matplotlib",
-    "numpy",
-    "pygrib",
-    "scipy",
-    "urllib3",
-    #"netcdf4",   # for MERRA, which is currently not supported
-    #"pyhdf",     # for MERRA, which is currently not supported
-]
-dynamic = ["version"]
+
+# see section: setuptools_scm
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
+# dependencies will be read from text files
+dynamic = ["version", "readme", "dependencies", "optional-dependencies"]
 
 [project.urls]
 "Homepage" = "https://github.com/insarlab/PyAPS"
-"Bug Tracker" = "https://github.com/insarlab/PyAPS/issues"
+"Issues" = "https://github.com/insarlab/PyAPS/issues"
 
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+readme = { file = ["README.md"], content-type = "text/markdown" }
+
+# extra requirements: `pip install pyaps3[test]` or `pip install .[test]`
+[tool.setuptools.dynamic.optional-dependencies.test]
+file = ["tests/requirements.txt"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,7 @@
-# for running
 cdsapi>=0.7.0
-matplotlib
 numpy
 pygrib
 scipy
 urllib3
 #netcdf4  #for MERRA, which is currently not supported
 #pyhdf    #for MERRA, which is currently not supported
-# for packaging and installation
-pip
-setuptools
-setuptools_scm
-wheel

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+matplotlib
 pip
 setuptools
 setuptools_scm

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+pip
+setuptools
+setuptools_scm
+wheel


### PR DESCRIPTION
+ requirements.txt:
   - move the testing-/packaging-related dependencies into the new `tests/requirements.txt` file

+ pyproject.toml:
   - use dynamic files for dependencies and optional dependencies, to avoid duplicating the list of dependencies, to be consistent with mintpy
   - use dynamic files for readme as well