### PR TITLE
`autoget.ECMWFdload()`: bugfix for `snwe` in `numpy.int64` or `float`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ apt install python3-pyaps3
 
 #### b. Install the development version
 
+<p>
+<details>
+<p><summary>Click to expand for more details</summary></p>
+
 The development version can be installed via `pip` as:
 
 ```bash
@@ -56,6 +60,8 @@ Test the installation by running:
 ```bash
 python PyAPS/tests/test_calc.py
 ```
+</details>
+</p>
 
 ### 2. Account setup for [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5)
 

--- a/src/pyaps3/autoget.py
+++ b/src/pyaps3/autoget.py
@@ -10,6 +10,7 @@
 
 import os.path
 import configparser
+import math
 import urllib3
 import cdsapi
 import pyaps3 as pa
@@ -39,6 +40,17 @@ def ECMWFdload(bdate,hr,filedir,model='ERA5',datatype='fc',humidity='Q',snwe=Non
 
     #-------------------------------------------
     # Initialize
+
+    # Ensure snwe is in native int, not numpy.int32/64 or float etc.
+    # Note that even though cdsapi support float, we still use int
+    # for file naming simplicity at the cost of slightly larger file size.
+    if snwe is not None:
+        s, n, w, e = snwe
+        snwe = (math.floor(s), math.ceil(n), math.floor(w), math.ceil(e))
+        snwe = tuple(int(x) for x in snwe)
+        if (s, n, w, e) != snwe:
+            print(f'WARNING: input area ({s}, {n}, {w}, {e}) is NOT exact integer,',
+                  f'\n\tconvert to its bounding box in integer {snwe} and continue.')
 
     # Check data
     assert model in ('ERA5', 'ERAINT', 'HRES'), f'Unknown model for ECMWF: {model}'

--- a/src/pyaps3/autoget.py
+++ b/src/pyaps3/autoget.py
@@ -238,4 +238,3 @@ def NARRdload(bdate,hr,filedir):
             urllib3.urlretrieve(weburl,dname)
 
     return flist
-


### PR DESCRIPTION
+ `autoget.ECMWFdload()`: bugfix if input `snwe` is in `numpy.int64` or `float`, as reported in https://github.com/insarlab/MintPy/issues/1321

+ `README`: collapse dev install note for a simpler first look

## Summary by Sourcery

Fix bug in `ECMWFdload` for handling `snwe` parameter with incorrect types and improve the README by collapsing the developer installation notes for better readability.

Bug Fixes:
- Fix a bug in `autoget.ECMWFdload()` where the `snwe` parameter was not handled correctly when provided as `numpy.int64` or `float` types.  The function now converts these types to native integers and prints a warning if the conversion results in a change of area to prevent unexpected behavior downstream.

Documentation:
- Collapse the developer installation notes in the README for a cleaner first look, making it easier for new users to get started with the project.  The detailed instructions are still available via an expandable section.