### PR TITLE
fix: type change

### DIFF
--- a/src/pyaps3/autoget.py
+++ b/src/pyaps3/autoget.py
@@ -130,8 +130,9 @@ def ECMWFdload(bdate,hr,filedir,model='ERA5',datatype='fc',humidity='Q',snwe=Non
 
             # download a geographical area subset
             if snwe is not None:
-                s, n, w, e = snwe
+                s, n, w, e = [float(v) for v in snwe]
                 indict['area'] = [n, w, s, e]
+
 
             # Assert grib file not yet downloaded
             if not os.path.exists(fname):


### PR DESCRIPTION
BUG: 
Failed to download grd file. Raised Exception.

REASON:
numpy.int64 was the type of snwe list value which cannot be serialize. 

FIX:
To fix it; values are converted into float.

## Summary by Sourcery

Bug Fixes:
- Convert snwe list values to floats before setting the download area to prevent serialization issues with numpy.int64