### PR TITLE
`circleci`: update `miniforge` setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,13 @@ jobs:
             apt update
             apt-get update --yes && apt-get upgrade --yes
             apt-get install --yes git wget
-            # download and install miniforge
+            # install miniforge (https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline)
             mkdir -p ${HOME}/tools
             cd ${HOME}/tools
-            wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-            bash Miniforge3-Linux-x86_64.sh -b -p ${HOME}/tools/miniforge
-            ${HOME}/tools/miniforge/bin/mamba init bash
+            wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+            bash Miniforge3.sh -b -p ${HOME}/tools/miniforge
+            source "${HOME}/tools/miniforge/etc/profile.d/conda.sh"
+            source "${HOME}/tools/miniforge/etc/profile.d/mamba.sh"
             # modify/export env var PATH to BASH_ENV to be shared across run steps
             echo 'export PATH=${CONDA_PREFIX}/bin:${PATH}' >> ${BASH_ENV}
 


### PR DESCRIPTION
+ `.circleci/config.yml`: replace `mamba init bash` with `source conda/mamba.sh`, as suggested by its GitHub repo readme at https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline, to fix the current circle CI environment setup error, as shown in https://github.com/insarlab/MintPy/pull/1352.

## Summary by Sourcery

Update the CircleCI Miniforge installation to use the appropriate installer dynamically and source the official initialization scripts to resolve CI environment errors.

Bug Fixes:
- Fix CircleCI environment setup by sourcing conda and mamba initialization scripts instead of using `mamba init`. 

CI:
- Download the OS/architecture-specific Miniforge3 installer and initialize it via `conda.sh` and `mamba.sh` in the CircleCI config.